### PR TITLE
Add script `fetch_touchpad_live_meets.py` to pull meets from TouchPad Live

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,108 @@ Take the generated `.sd3` file and import it into a SwimTopia meet.
 
 - Best to have imported the Roster to SwimTopia, in the Season of this meet, before importing the meet
 - There's a bug in SwimTopia import such that auto-creating Events on import doesn't work. Create the standard 64 events manually, use a SwimTopia team or league template, or find a `.ev3` for uploading (like the [one in this repo](event_template_dual_64.ev3)).
+
+## `fetch_touchpad_live_meets.py`
+
+_Script to convert, read, or write Swimming Data Interchange Files (SDIF, .sd3) from a 
+Team Unify and/or TouchPad source._
+
+This script can be used to import swim meet results from Team Unify to SwimTopia.
+
+### Quickstart
+
+For help: 
+```shell
+python3 fetch_touchpad_live_meets.py -h
+```
+
+Get meets for team name like "Willowsford North":
+```shell
+python3 fetch_touchpad_live_meets.py --team "Willowsford North"
+```
+
+Results are stored in `<team_id>_meets.json`
+
+Example console output:
+
+```
+〉python3 fetch_touchpad_live_meets.py -i 5721
+Fetching all meets that occurred in the state of VA from 2012 to 2023
+	Fetching meets for 2012
+	Found 0 meets from 2012
+	Fetching meets for 2013
+	Found 109 meets from 2013
+	Fetching meets for 2014
+	Found 119 meets from 2014
+	Fetching meets for 2015
+	Found 187 meets from 2015
+	Fetching meets for 2016
+	Found 155 meets from 2016
+	Fetching meets for 2017
+	Found 165 meets from 2017
+	Fetching meets for 2018
+	Found 162 meets from 2018
+	Fetching meets for 2019
+	Found 180 meets from 2019
+	Fetching meets for 2020
+	Found 9 meets from 2020
+	Fetching meets for 2021
+	Found 167 meets from 2021
+	Fetching meets for 2022
+	Found 175 meets from 2022
+	Fetching meets for 2023
+	Found 192 meets from 2023
+Found 1620 meets run in your state. Searching through them for your team with ID(s) ['5721']...
+Finished searching through 0% of meets
+Finished searching through 0% of meets
+Finished searching through 10% of meets
+Finished searching through 20% of meets
+Finished searching through 30% of meets
+Finished searching through 40% of meets
+Finished searching through 50% of meets
+Finished searching through 60% of meets
+Finished searching through 70% of meets
+Finished searching through 80% of meets
+Finished searching through 90% of meets
+Finished searching through 100% of meets
+Filtering out 1542 of 1620 meets.
+	250 meets are empty.
+	1292 meets do not contain your team(s) (['5721']).
+Found 78 meets your team participated in:
+[{'children': [],
+  'city': 'South Riding',
+  'id': 4283,
+  'name': '2014 ODSL All-Star Meet',
+  'startDate': '2014-08-02',
+  'state': 'VA',
+  'url': 'http://www.touchpadlive.com/4283'},
+ {'children': [],
+  'city': 'Leesburg',
+  'id': 4281,
+  'name': '2014 ODSL Divisional Meet',
+  'startDate': '2014-07-26',
+  'state': 'VA',
+  'url': 'http://www.touchpadlive.com/4281'},
+ {'children': [],
+  'city': 'Leesburg',
+  'id': 3543,
+  'name': '2014 Willowsford at Tavistock',
+  'startDate': '2014-07-16',
+  'state': 'VA',
+  'url': 'http://www.touchpadlive.com/3543'},
+ {'children': [],
+  'city': 'Leesburg',
+  'id': 3581,
+  'name': '2014 Woodlea Watermocs vs Willowsford Waves',
+  'startDate': '2014-06-25',
+  'state': 'VA',
+  'url': 'http://www.touchpadlive.com/3581'},
+ {'children': [],
+  'city': 'Leesburg',
+  'id': 3578,
+  'name': 'Willowsford Farms at Evergreen Meadows',
+  'startDate': '2014-06-18',
+  'state': 'VA',
+  'url': 'http://www.touchpadlive.com/3578'},
+  ...
+```

--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ Fetching all meets that occurred in the state of VA from 2012 to 2023
 	Found 192 meets from 2023
 Found 1620 meets run in your state. Searching through them for your team with ID(s) ['5721']...
 Finished searching through 0% of meets
-Finished searching through 0% of meets
 Finished searching through 10% of meets
 Finished searching through 20% of meets
 Finished searching through 30% of meets

--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ Take the generated `.sd3` file and import it into a SwimTopia meet.
 
 ## `fetch_touchpad_live_meets.py`
 
-_Script to convert, read, or write Swimming Data Interchange Files (SDIF, .sd3) from a 
-Team Unify and/or TouchPad source._
+_**Script to pull meet info for a team or set of teams from TouchPad Live via their REST API.**_
+
+Can be expanded to get meet entry and result details, however results do not have the USA Swimming Number for swimmers, so not readily useful for building an SDIF .sd3 results file.
 
 This script can be used to import swim meet results from Team Unify to SwimTopia.
 

--- a/fetch_touchpad_live_meets.py
+++ b/fetch_touchpad_live_meets.py
@@ -1,0 +1,220 @@
+"""
+Script to use the TouchPad Live REST API endpoints to collect all TouchPad Live meets for your team
+"""
+
+import json
+import urllib.request
+import urllib.parse
+import argparse
+import datetime
+import time
+import pprint as pp
+from typing import List, Dict, Tuple, Union
+from statistics import mode, StatisticsError
+from functools import wraps
+
+_DEFAULT_STATE = "VA"
+_SEARCH_URL_TEMPLATE = (
+    "https://www.touchpadlive.com/rest/touchpadlive/meets?offset={offset}&pattern={team}&state={state}&year={year}"
+)
+_MEET_URL_TEMPLATE = "https://www.touchpadlive.com/rest/touchpadlive/meets/{meet_id}"
+_MEET_TEAMS_URL_TEMPLATE = "https://www.touchpadlive.com/rest/touchpadlive/meets/{meet_id}/teams"
+_MEET_ATTENDEES_URL_TEMPLATE = "https://www.touchpadlive.com/rest/touchpadlive/meets/{meet_id}/attendees"
+
+
+def _build_search_url(year=datetime.date.today().year, team="", state=_DEFAULT_STATE, offset=0):
+    return _SEARCH_URL_TEMPLATE.format(**locals())
+
+
+def infer_team_id(meets: List[Dict]):
+    print("Determining your specific team ID from the team name you provided...")
+    team_ids = []
+    for meet in meets:
+        meet_teams_url = _MEET_TEAMS_URL_TEMPLATE.format(meet_id=meet["id"])
+        teams = get_json_from_url_with_retry(meet_teams_url)
+        if not teams:
+            continue  # must be teams in the meet to count it
+        for team in teams:
+            team_ids.append(team["teamID"])
+    team_id = None
+    try:
+        team_id = mode(team_ids)
+        print(
+            f"Inferred that your team ID is {team_id}, beause that occurred most frequently in the meets found with your provided team name"
+        )
+    except StatisticsError:
+        raise SystemExit(
+            "Could not get a TouchPad Live Team ID from that Team Name. ",
+            "Either try a more unique fragment of your team name, ",
+            "or search the request/response payloads using browser tools ",
+            "for a meet you know your team participated in to get the integer team ID, and pass it in with the --team-ids arg",
+        )
+    return team_id
+
+
+def fetch_meets(
+    team_name: str = "",
+    state: str = _DEFAULT_STATE,
+    years: List[int] = [datetime.date.today().year],
+):
+    all_meets = []
+    for year in years:
+        print(f"\tFetching meets for {year}")
+        meets_in_year = 0
+        offset = 0
+        url = _build_search_url(year=year, team=team_name, state=state, offset=offset)
+        while True:
+            data = get_json_from_url_with_retry(url)
+            meets_in_year += len(data)
+            if not data:
+                break
+            else:
+                all_meets.extend(data)
+                offset += 1  # offset is by page, not by meet items ¯\_(ツ)_/¯
+                url = _build_search_url(year=year, team=team_name, state=state, offset=offset)
+        print(f"\tFound {meets_in_year} meets from {year}")
+
+    return all_meets
+
+
+def filter_meets_by_team_ids(team_ids: List[int]):
+    """Filter out meets that do not include the given team IDs"""
+    empty_meets = []
+    not_our_team = []
+    meet_count = len(all_state_meets)
+    progress_updates = 0
+    print(f"Found {meet_count} meets run in your state. Searching through them for your team with ID(s) {team_ids}...")
+    for i, meet in enumerate(all_state_meets):
+        # Update progress
+        finished = 100 * (i / meet_count)
+        if divmod(finished, 10) == (progress_updates, 0):
+            progress_updates += 1
+            print(f"Finished searching through {int(finished)}% of meets")
+
+        meet_id = meet["id"]
+        meet_teams_url = _MEET_TEAMS_URL_TEMPLATE.format(meet_id=meet_id)
+        teams = get_json_from_url_with_retry(meet_teams_url)
+        if not teams:
+            empty_meets.append(meet_id)
+            continue
+        if not [team_id for team_id in team_ids if team_id in [t["teamID"] for t in teams]]:
+            not_our_team.append(meet_id)
+
+    to_remove = empty_meets + not_our_team
+    print(f"Filtering out {len(to_remove)} of {meet_count} meets.")
+    print(f"\t{len(empty_meets)} meets are empty.")
+    print(f"\t{len(not_our_team)} meets do not contain your team(s) ({team_ids}).")
+    participated_meets = [m for m in all_state_meets if m["id"] not in to_remove]
+    return participated_meets
+
+
+def retryable(
+    exception_to_check: Union[Exception, Tuple[Exception]] = (Exception,),
+    tries: int = 5,
+    pause_before_try: float = 0.0,
+    backoff: int = 1,
+    backoff_factor: int = 2,
+):
+    """Decorator used to retry decorated function with exponential backoff.
+
+    Args:
+        exception_to_check  Union[Exception, Tuple[Exception]]): the exception to check. may be a tuple of
+            exceptions to check
+        tries (int): number of times to try (not retry) before giving up
+        pause_before_try (float): how long to pause in seconds before ANY and EVERY try
+        backoff (int): how many seconds to backoff the first time a try fails
+        backoff_factor (int): backoff multiplier e.g. value of 2 will double the delay
+            each retry
+    """
+
+    def decorator(fn):
+
+        @wraps(fn)
+        def retry(*args, **kwargs):
+            this_try = 1
+            current_backoff = backoff
+            while this_try < tries:
+                if pause_before_try:
+                    time.sleep(pause_before_try)
+                try:
+                    return fn(*args, **kwargs)  # attempt a (re)try if allowed more than one try
+                except Exception as exc_val:
+                    exc_type = type(exc_val)
+
+                    if exc_type is not None:
+                        print(f"Found error: {str(exc_type)}... checking if in {exception_to_check}")
+                    else:
+                        print("NONE exception")
+                        return
+
+                    if not issubclass(exc_type, exception_to_check):
+                        print("OTHER exception")
+                        return
+                    if exc_type is not None and issubclass(exc_type, exception_to_check):
+                        # Try again if you have tries left
+                        if this_try < tries:  # do the retry
+                            print(
+                                f"Retrying in {pause_before_try + current_backoff:.2f} seconds..."
+                                f" After receiving retryable Error: {str(exc_val)}"
+                            )
+                            this_try += 1
+                            time.sleep(current_backoff)
+                            current_backoff *= backoff_factor
+                        else:
+                            print("No more tries left :(")
+                    if exc_type is not None and not issubclass(exc_type, exception_to_check):
+                        print("NON-RETRYABLE exception" + str(exc_val))
+                        raise exc_val
+
+            # Last and unguarded call attempt, after all retries (if any) have been attempted
+            return fn(*args, **kwargs)
+
+        return retry  # wrapper --around--> wrapped function
+
+    return decorator  # @retryable(arg[, ...]) decorator --delegating-to--> wrapper
+
+
+@retryable()
+def get_json_from_url_with_retry(url: str):
+    with urllib.request.urlopen(url) as response:
+        return json.loads(response.read())
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        prog="TouchPad Live Meet Fetcher",
+        description="Script to use the TouchPad Live REST API endpoints to collect all TouchPad Live meets for your team",
+        epilog="",
+    )
+
+    team_args = parser.add_mutually_exclusive_group(required=True)
+    team_args.add_argument("-t", "--team")
+    team_args.add_argument("-i", "--team-ids", nargs="+")
+    parser.add_argument("-y", "--year", required=False)
+    parser.add_argument("-s", "--state", default=_DEFAULT_STATE)
+
+    # A single meet with ID=1: https://www.touchpadlive.com/rest/touchpadlive/meets/1
+
+    # Search for Meets: https://www.touchpadlive.com/rest/touchpadlive/meets?offset=0&state=VA&year=2023
+
+    args = parser.parse_args()
+    if args.team:
+        team = urllib.parse.quote_plus(args.team)
+    state = args.state
+    years = range(2012, datetime.date.today().year) if not args.year else [args.year]
+
+    team_ids = args.team_ids
+    if not args.team_ids:
+        print(f'Fetching meets that match your provided team name: "{team}"...')
+        team_ids = [infer_team_id(fetch_meets(team, state, years))]
+
+    print(f"Fetching all meets that occurred in the state of {state} from {min(years)} to {max(years)}")
+    all_state_meets = fetch_meets(years=years)
+
+    participated_meets = filter_meets_by_team_ids(team_ids)
+    for pm in participated_meets:
+        pm["url"] = f"http://www.touchpadlive.com/{pm['id']}"
+    print(f"Found {len(participated_meets)} meets your team participated in:")
+    pp.pprint(participated_meets)
+    with open(f"{'_'.join([str(tid) for tid in team_ids])}_meets.json", "w") as meets_file:
+        json.dump(participated_meets, meets_file)


### PR DESCRIPTION
**High-Level Description**

Use the TouchPad Live REST API to pull meet details for a team or set of teams. 

**Technical Details**
See README.md for getting help on the script with the `-h` flag. 
Uses `urllib` to make requests, with a retry decorator, and multi-threading to speed up the meet inspection. 
Results saved to a `{team_id}_meet.json` file.